### PR TITLE
fix: local frame to rerun 0.21 with axis length

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Setup environment
         uses: conda-incubator/setup-miniconda@v2
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
           activate-environment: pyorerun
@@ -28,11 +27,11 @@ jobs:
         
       - name: Print mamba info
         run: | 
-          mamba info
-          mamba list
+          conda info
+          conda list
 
       - name: Install extra dependencies
-        run: mamba install pytest-cov black pytest pytest-cov codecov -cconda-forge
+        run: conda install pytest-cov black pytest pytest-cov codecov -cconda-forge
 
       - name: Install pyorerun with pip
         run: pip install .

--- a/examples/biorbd/msk_model.py
+++ b/examples/biorbd/msk_model.py
@@ -32,7 +32,7 @@ def main():
     print(f"Time to run: {toc - tic}")
 
     tic = time.time()
-    viz.rerun_with_chunks("msk_model with chunk")
+    viz.rerun_by_frame("msk_model with chunk")
     toc = time.time()
     print(f"Time to run with chunks: {toc - tic}")
 

--- a/pyorerun/biorbd_components/local_frame.py
+++ b/pyorerun/biorbd_components/local_frame.py
@@ -16,7 +16,7 @@ class LocalFrameUpdater(Component):
         """
         self.name = name
         self.transform_callable = transform_callable
-        self.scale = 0.25
+        self.scale = 0.1
 
     @property
     def nb_components(self):
@@ -41,7 +41,8 @@ class LocalFrameUpdater(Component):
         homogenous_matrices = self.transform_callable(q)
         return rr.Transform3D(
             translation=homogenous_matrices[:3, 3],
-            mat3x3=homogenous_matrices[:3, :3] * self.scale,
+            mat3x3=homogenous_matrices[:3, :3],
+            axis_length=self.scale,
         )
 
     def compute_all_transforms(self, q: np.ndarray) -> np.ndarray:
@@ -62,5 +63,6 @@ class LocalFrameUpdater(Component):
                 rr.components.PoseTransformMat3x3Batch(
                     [homogenous_matrices[:3, :3, f] for f in range(homogenous_matrices.shape[2])]
                 ),
+                rr.components.AxisLengthBatch([self.scale] * homogenous_matrices.shape[2]),
             ]
         }

--- a/tests/test_local_frame.py
+++ b/tests/test_local_frame.py
@@ -13,7 +13,7 @@ def test_local_frame():
     # Test initialization
     assert local_frame.name == "test"
     assert local_frame.transform_callable == dummy_callable_transform
-    assert local_frame.scale == 0.25
+    assert local_frame.scale == 0.1
 
     # Test nb_components property
     assert local_frame.nb_components == 1


### PR DESCRIPTION
@EveCharbie
fixed !
I had to update and following the migration guide :)
https://rerun.io/docs/reference/migration/migration-0-21

Enjoy !

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyomeca/pyorerun/47)
<!-- Reviewable:end -->
