### PR TITLE
Fixed reordering of markers following PyoMarkers

### DIFF
--- a/pyorerun/phase_rerun.py
+++ b/pyorerun/phase_rerun.py
@@ -97,9 +97,8 @@ class PhaseRerun:
             muscle_colors = muscle_activations_intensity.to_colors()
 
         if tracked_markers is not None:
+            tracked_markers = check_and_adjust_markers(model, tracked_markers)
             self.__add_tracked_markers(model, tracked_markers)
-
-        if tracked_markers is not None:
             tracked_markers = tracked_markers.to_numpy()[:3, :, :]
         self.models.add_animated_model(model, q, tracked_markers, muscle_colors)
 
@@ -121,8 +120,6 @@ class PhaseRerun:
         tracked_markers: PyoMarkers,
     ) -> None:
         """Add the tracked markers to the phase."""
-
-        tracked_markers = check_and_adjust_markers(model, tracked_markers)
         self.add_xp_markers(f"{model.name}_tracked_markers", tracked_markers)
 
     def add_xp_markers(self, name, markers: PyoMarkers) -> None:

--- a/pyorerun/utils/markers_utils.py
+++ b/pyorerun/utils/markers_utils.py
@@ -11,7 +11,7 @@ def check_and_adjust_markers(model: AbstractModel, tracked_markers: PyoMarkers) 
     """
 
     shape_of_markers_is_not_consistent = model.nb_markers != tracked_markers.shape[1]
-    tracked_marker_names = tuple(tracked_markers.channel.data)
+    tracked_marker_names = tracked_markers.marker_names
     if shape_of_markers_is_not_consistent:
         raise ValueError(
             f"The markers of the model and the tracked markers are inconsistent. "
@@ -33,9 +33,9 @@ def check_and_adjust_markers(model: AbstractModel, tracked_markers: PyoMarkers) 
     if names_are_ordered_differently:
         # Replace the markers in the right order based on the names provided in PyoMarkers
         reordered_markers = np.zeros_like(tracked_markers.to_numpy())
-        for marker in model.marker_names:
+        for i_marker, marker in enumerate(model.marker_names):
             marker_index = tracked_marker_names.index(marker)
-            reordered_markers[:, marker_index, :] = tracked_markers.to_numpy()[:, model.marker_names.index(marker), :]
-        tracked_markers = PyoMarkers(reordered_markers, channels=list(model.marker_names))
+            reordered_markers[:, i_marker, :] = tracked_markers.to_numpy()[:, marker_index, :]
+        tracked_markers = PyoMarkers(reordered_markers, marker_names=list(model.marker_names))
 
     return tracked_markers


### PR DESCRIPTION
I don't understand why it changed anything, but now it seems to work better...