### PR TITLE
Added 1 line to fix error in loading Stl meshes

### DIFF
--- a/pyorerun/model_components/mesh.py
+++ b/pyorerun/model_components/mesh.py
@@ -64,6 +64,7 @@ class TransformableMeshUpdater(Component):
         if file_path.endswith(".stl") or file_path.endswith(".STL"):
             mesh = load(file_path, file_type="stl")
             mesh.apply_scale(scale_factor)
+            mesh.metadata["file_name"] = file_path
             return cls(name, mesh, transform_callable)
         elif file_path.endswith(".vtp"):
             output = read_vtp_file(file_path)
@@ -156,3 +157,4 @@ class TransformableMeshUpdater(Component):
                 ),
             ]
         }
+


### PR DESCRIPTION
Ran into the following error when using a BioMod linked to STL meshes
```
  File "/home/pierre/miniconda3/envs/pyorerun_sandbox/lib/python3.12/site-packages/pyorerun/model_components/mesh.py", line 18, in __init__
    mesh.metadata["file_name"] if "file_name" in mesh.metadata else mesh.metadata["header"].replace(" ", "")
                                                                    ~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'header'
```

This PR fixes that problem