### PR TITLE
BioBuddy interface

### DIFF
--- a/examples/biobuddy/from_biobuddy_model.py
+++ b/examples/biobuddy/from_biobuddy_model.py
@@ -18,14 +18,12 @@ def main():
     nb_seconds = 1
     t_span = np.linspace(0, nb_seconds, nb_frames)
 
-
     # Creating the model
     biobuddy_model = biobuddy.BiomechanicalModelReal().from_biomod(
         "models/Wu_Shoulder_Model_kinova_scaled_adjusted_2.bioMod"
     )
     display_options = DisplayModelOptions()
     prr_model = BiobuddyModel.from_biobuddy_object(biobuddy_model, options=display_options)
-
 
     # building some generalized coordinates
     q = np.zeros((biobuddy_model.nb_q, nb_frames))
@@ -35,7 +33,6 @@ def main():
     q[13, :] = np.linspace(0, np.pi / 8, nb_frames)
     q[14, :] = np.linspace(0, np.pi / 8, nb_frames)
     q[15, :] = np.linspace(0, np.pi / 8, nb_frames)
-
 
     # Animate the model
     viz = PhaseRerun(t_span)

--- a/examples/biobuddy/from_biobuddy_model.py
+++ b/examples/biobuddy/from_biobuddy_model.py
@@ -1,0 +1,47 @@
+"""
+To run this example, you need to install biobuddy:
+    `pip install biobuddy`
+    or
+    `conda-forge install -c conda-forge biobuddy`
+"""
+
+import numpy as np
+import biobuddy
+
+from pyorerun import PhaseRerun, BiobuddyModel, DisplayModelOptions
+
+
+def main():
+
+    # building some time components
+    nb_frames = 50
+    nb_seconds = 1
+    t_span = np.linspace(0, nb_seconds, nb_frames)
+
+
+    # Creating the model
+    biobuddy_model = biobuddy.BiomechanicalModelReal().from_biomod(
+        "models/Wu_Shoulder_Model_kinova_scaled_adjusted_2.bioMod"
+    )
+    display_options = DisplayModelOptions()
+    prr_model = BiobuddyModel.from_biobuddy_object(biobuddy_model, options=display_options)
+
+
+    # building some generalized coordinates
+    q = np.zeros((biobuddy_model.nb_q, nb_frames))
+    q[10, :] = np.linspace(0, np.pi / 8, nb_frames)
+    q[12, :] = np.linspace(0, np.pi / 3, nb_frames)
+    q[11, :] = np.linspace(0, np.pi / 4, nb_frames)
+    q[13, :] = np.linspace(0, np.pi / 8, nb_frames)
+    q[14, :] = np.linspace(0, np.pi / 8, nb_frames)
+    q[15, :] = np.linspace(0, np.pi / 8, nb_frames)
+
+
+    # Animate the model
+    viz = PhaseRerun(t_span)
+    viz.add_animated_model(prr_model, q)
+    viz.rerun("msk_model")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/biobuddy/models/Wu_Shoulder_Model_kinova_scaled_adjusted_2.bioMod
+++ b/examples/biobuddy/models/Wu_Shoulder_Model_kinova_scaled_adjusted_2.bioMod
@@ -1,0 +1,1539 @@
+version 4
+
+// File extracted from Models/Wu_Shoulder_Model_kinova_scaled_adjusted_2.osim
+
+// Biomod not include all Osim features as the optimisation is performed on a third part software.
+// The original file contained some of these features, corresponding warnings are shown in the end of the file.
+
+
+gravity	0 -9.8000000000000007 0
+
+// SEGMENT DEFINITION
+
+// Information about ground segment
+
+    //True segment where are applied inertial values.
+	// Segment
+	segment ground
+		parent base 
+		RTinMatrix	0
+		RT	0	 0	 0	xyz	0	 0	 0
+	endsegment
+
+	// Markers
+
+// Information about thorax segment
+	// Segment
+	segment thorax_parent_offset
+		parent ground 
+		RTinMatrix	0
+		RT	0 0 0	xyz	0 0 0
+	endsegment
+
+	// Segments to define transformation axis.
+	// Segment
+	segment thorax_translation
+		parent thorax_parent_offset 
+		RTinMatrix	1
+		RT
+			1.0		0.0		0.0		0
+			0.0		1.0		0.0		0
+			0.0		0.0		1.0		0
+			0		0		0		1
+		translations xyz
+		// ranges
+				// -20 20
+				// -2 4
+				// -5 5
+	endsegment
+
+// Rotation transform was initially an orthogonal basis
+	// Segment
+	segment thorax_rotation_transform
+		parent thorax_translation 
+		RTinMatrix	1
+		RT
+			0.0		1.0		0.0		0
+			0.0		0.0		1.0		0
+			1.0		0.0		0.0		0
+			0		0		0		1
+		rotations xyz
+		// ranges
+				// -1.5708 1.5708
+				// -1.5708 1.5708
+				// -1.5708 1.5708
+	endsegment
+
+
+    // Segment to cancel transformation bases effect.
+	// Segment
+	segment thorax_reset_axis
+		parent thorax_rotation_transform 
+		RTinMatrix	1
+		RT
+			0.0		0.0		1.0		0
+			1.0		0.0		0.0		0
+			0.0		1.0		0.0		0
+			0		0		0		1
+	endsegment
+
+
+    //True segment where are applied inertial values.
+	// Segment
+	segment thorax
+		parent thorax_reset_axis 
+		RTinMatrix	0
+		RT	-0.0	 0.0	 -0.0	xyz	-0.0	 -0.0	 -0.0
+		mass	20
+		inertia
+			1.4396329067378999	0	0
+			0	0.77762242825264982	0
+			0	0	1.4396329067378999
+		com	-0.030878455125849764 0.31322806786246754 0
+		meshfile	../biorbd/models/Geometry_cleaned/thorax.vtp
+		meshcolor	1 1 1
+		meshscale	1.0292818375283255 0.97883771207021109 1
+	endsegment
+	// Segment
+	segment thorax_geom_2
+		parent thorax 
+		RTinMatrix	1
+		RT
+			1		0		0		0
+			0		1		0		0
+			0		0		1		0
+			0		0		0		1
+	endsegment
+
+
+	// Markers
+
+	marker	MAN
+		parent	thorax
+		position	0.028585125116334487 -0.0096469628941172614 0.0022341310733218784
+	endmarker
+
+	marker	XYP
+		parent	thorax
+		position	0.093098348228785266 -0.16977435086026191 -0.0015147799744307244
+	endmarker
+
+	marker	C7
+		parent	thorax
+		position	-0.115671464229821 0.050907333697403023 -0.0019490996456002982
+	endmarker
+
+	marker	T10
+		parent	thorax
+		position	-0.12411576888420972 -0.18842166787031064 0.0018790143716797252
+	endmarker
+
+// Information about clavicle segment
+	// Segment
+	segment clavicle_parent_offset
+		parent thorax 
+		RTinMatrix	0
+		RT	0 0 0	xyz	0.0065102076223666587 0.0067833453446465635 0.025465000000000002
+	endsegment
+
+	// Segments to define transformation axis.
+	// Segment
+	segment clavicle_translation
+		parent clavicle_parent_offset 
+		RTinMatrix	1
+		RT
+			1.0		0.0		0.0		0
+			0.0		1.0		0.0		0
+			0.0		0.0		1.0		0
+			0		0		0		1
+	endsegment
+
+	// Segment
+	segment clavicle_sternoclavicular_r1
+		parent clavicle_translation 
+		RTinMatrix	1
+		RT
+			0.015299995322998767		0.05024789063996113		0.9986195770308885		0
+			0.9892986975709203		0.14417284032013652		-0.0224115840249048		0
+			-0.1450999556429883		0.9882759440562433		-0.04750432898319804		0
+			0		0		0		1
+		rotations x
+		// ranges
+				// -1.570796326795 1.570796326795
+	endsegment
+
+	// Segment
+	segment clavicle_sternoclavicular_r2
+		parent clavicle_sternoclavicular_r1 
+		RTinMatrix	1
+		RT
+			0.6309281305459133		1.9627784775201133e-05		-0.775841281255766		0
+			0.766619938593272		-0.1537361093016383		0.6234252789613541		0
+			-0.1192625835586607		-0.9881119411845729		-0.09701148309024395		0
+			0		0		0		1
+		rotations y
+		// ranges
+				// -1.570796326795 1.570796326795
+	endsegment
+
+	// Segment
+	segment clavicle_sternoclavicular_r3
+		parent clavicle_sternoclavicular_r2 
+		RTinMatrix	1
+		RT
+			-0.2198132687855211		0.5918071766218879		0.7755297496322461		0
+			-0.9374553183394769		-0.3481056180525971		-6.926217681835036e-05		0
+			0.2699252729605994		-0.7270397130687218		0.6313110189424045		0
+			0		0		0		1
+		//rotations z
+		// ranges
+				// -1.570796326795 1.570796326795
+	endsegment
+
+
+    // Segment to cancel transformation bases effect.
+	// Segment
+	segment clavicle_reset_axis
+		parent clavicle_sternoclavicular_r3 
+		RTinMatrix	1
+		RT
+			0.9269653601051225		-0.34441490614047904		0.14870640064713217		0
+			0.3604972762830375		0.9274872248617597		-0.09904121117364527		0
+			-0.10381201740497924		0.14541602437997073		0.9839091649618028		0
+			0		0		0		1
+	endsegment
+
+
+    //True segment where are applied inertial values.
+	// Segment
+	segment clavicle
+		parent clavicle_reset_axis 
+		RTinMatrix	0
+		RT	-0.0	 0.0	 -0.0	xyz	-0.0	 -0.0	 -0.0
+		mass	0.20000000000000001
+		inertia
+			0	0	0
+			0	0	0
+			0	0	0
+		com	-0.017725195231248728 0.0084954100000000001 0.065984600000000004
+		meshfile	../biorbd/models/Geometry_cleaned/clavicle.vtp
+		meshcolor	1 1 1
+		meshscale	1.3934354177311215 1 1
+	endsegment
+
+	// Markers
+
+	marker	CLAV_SC
+		parent	clavicle
+		position	0.014925539756743711 -0.01310540661257345 -0.0057477766590993129
+	endmarker
+
+	marker	CLAV_AC
+		parent	clavicle
+		position	-0.025964972865416991 0.02790861704057318 0.11784523434555516
+	endmarker
+
+	marker	SCAP_Cor
+		parent	clavicle
+		position	0.035971339437720018 0.0086023651223235131 0.11690363047522773
+	endmarker
+
+// Information about scapula segment
+	// Segment
+	segment scapula_parent_offset
+		parent clavicle 
+		RTinMatrix	0
+		RT	-0.52000000000000002 0.52000000000000002 0	xyz	-0.019967929536086972 0.020070000000000001 0.13553499999999999
+	endsegment
+
+	// Segments to define transformation axis.
+	// Segment
+	segment scapula_translation
+		parent scapula_parent_offset 
+		RTinMatrix	1
+		RT
+			1.0		0.0		0.0		0
+			0.0		1.0		0.0		0
+			0.0		0.0		1.0		0
+			0		0		0		1
+	endsegment
+
+// Rotation transform was initially an orthogonal basis
+	// Segment
+	segment scapula_rotation_transform
+		parent scapula_translation 
+		RTinMatrix	1
+		RT
+			0.0		0.0		-1.0		0
+			0.0		1.0		0.0		0
+			1.0		0.0		0.0		0
+			0		0		0		1
+		rotations xyz
+		// ranges
+				// -1.570796326795 1.570796326795
+				// -1.570796326795 1.570796326795
+				// -1.570796326795 1.570796326795
+	endsegment
+
+
+    // Segment to cancel transformation bases effect.
+	// Segment
+	segment scapula_reset_axis
+		parent scapula_rotation_transform 
+		RTinMatrix	1
+		RT
+			0.0		0.0		1.0		0
+			0.0		1.0		0.0		0
+			-1.0		-0.0		-0.0		0
+			0		0		0		1
+	endsegment
+
+
+    //True segment where are applied inertial values.
+	// Segment
+	segment scapula
+		parent scapula_reset_axis 
+		RTinMatrix	0
+		RT	0.5832133965420941	 -0.4458246964234714	 0.27717166315597463	xyz	-0.0	 -0.0	 -0.0
+		mass	0.5
+		inertia
+			0	0	0
+			0	0	0
+			0	0	0
+		com	-0.071999999999999995 -0.039023511475557673 -0.064675141995500701
+		meshfile	../biorbd/models/Geometry_cleaned/scapula.vtp
+		meshcolor	1 1 1
+		meshscale	1 1.0006028583476327 0.99500218454616463
+	endsegment
+
+	// Markers
+
+	marker	SCAP_IA
+		parent	scapula
+		position	-0.12780765790330895 -0.13084905009782843 -0.068130426094901456
+	endmarker
+
+	marker	SCAP_AA
+		parent	scapula
+		position	-0.096566064750645442 -0.014594355278280458 -0.088603698687889254
+	endmarker
+
+	marker	SCAP_AC
+		parent	scapula
+		position	-0.038104119032025596 0.0043635870624950668 0.018807466959583213
+	endmarker
+
+	marker	SCAP_BACK
+		parent	scapula
+		position	-0.073456722424290133 0.024307735983989387 0.0050615354081945535
+	endmarker
+
+	marker	SCAP_FRONT
+		parent	scapula
+		position	-0.022832618296041884 0.023083727808628662 0.057812244884366287
+	endmarker
+
+// Information about humerus segment
+	// Segment
+	segment humerus_parent_offset
+		parent scapula 
+		RTinMatrix	0
+		RT	0 0 0	xyz	-0.0095499999999999995 -0.034020497183819519 0.0089550196609154802
+	endsegment
+
+	// Segments to define transformation axis.
+	// Segment
+	segment humerus_translation
+		parent humerus_parent_offset 
+		RTinMatrix	1
+		RT
+			1.0		0.0		0.0		0
+			0.0		1.0		0.0		0
+			0.0		0.0		1.0		0
+			0		0		0		1
+	endsegment
+
+	// Segment
+	segment humerus_shoulder_plane
+		parent humerus_translation 
+		RTinMatrix	1
+		RT
+			9.999999900000002e-05		-0.5155907056664478		0.8568349982525074		0
+			0.9999999900000002		-3.412442977419667e-05		-0.0001372425695350605		0
+			9.999999900000002e-05		0.8568350034084143		0.5155906970980978		0
+			0		0		0		1
+		rotations x
+		// ranges
+				// -1.8999999999999999 0.34999999999999998
+	endsegment
+
+	// Segment
+	segment humerus_shoulder_ele
+		parent humerus_shoulder_plane 
+		RTinMatrix	1
+		RT
+			0.599339323201345		9.999999900000002e-05		-0.8004950753530928		0
+			0.6858628223174961		0.5155875497639124		0.5135773237703589		0
+			0.41277665223124305		-0.856836897273014		0.30894330684499716		0
+			0		0		0		1
+		rotations y
+		// ranges
+				// -0.29999999999999999 3
+	endsegment
+
+	// Segment
+	segment humerus_shoulder_rotation
+		parent humerus_shoulder_ele 
+		RTinMatrix	1
+		RT
+			0.7055251816279622		0.3783153988153252		0.5992592736938097		0
+			0.47256640009412343		-0.8812950683522974		-1.10037936450818e-17		0
+			0.5281242425707341		0.2831897976925027		-0.800555009285413		0
+			0		0		0		1
+		rotations z
+		// ranges
+				// 0 3
+	endsegment
+
+
+    // Segment to cancel transformation bases effect.
+	// Segment
+	segment humerus_reset_axis
+		parent humerus_shoulder_rotation 
+		RTinMatrix	1
+		RT
+			-0.4725696190041502		9.451377502117462e-05		0.8812933372387534		0
+			0.8812933196127876		-0.00017625916163265247		0.47256962845551265		0
+			0.0002000003643198341		0.9999999799999271		3.6632107145161935e-10		0
+			0		0		0		1
+	endsegment
+
+
+    //True segment where are applied inertial values.
+	// Segment
+	segment humerus
+		parent humerus_reset_axis 
+		RTinMatrix	0
+		RT	-0.0	 0.0	 -0.0	xyz	-0.0	 -0.0	 -0.0
+		mass	2.0325000000000002
+		inertia
+			0.010982745450000001	0	0
+			0	0.0029774225000000006	0
+			0	0	0.010982745450000001
+		com	0 -0.16121196000000002 0
+		meshfile	../biorbd/models/Geometry_cleaned/humerus.vtp
+		meshcolor	1 1 1
+		meshscale	0.84999999999999998 0.97999999999999998 0.84999999999999998
+	endsegment
+
+	// Markers
+
+	marker	EPI_lat
+		parent	humerus
+		position	0.016107563696706212 -0.27181098714413976 0.033175579021756274
+	endmarker
+
+	marker	EPI_med
+		parent	humerus
+		position	0.00026073737838142041 -0.27959075138295464 -0.042775935224929396
+	endmarker
+
+	marker	DELT
+		parent	humerus
+		position	0.022032005797263332 -0.14286187139203799 0.033221007147945403
+	endmarker
+
+	marker	ARM
+		parent	humerus
+		position	0.024058963177472747 -0.10652879921703907 0.040844028132537735
+	endmarker
+
+// Information about ulna segment
+	// Segment
+	segment ulna_parent_offset
+		parent humerus 
+		RTinMatrix	0
+		RT	0 0 0	xyz	0.0051850000000000004 -0.28459200000000001 -0.010454999999999999
+	endsegment
+
+	// Segments to define transformation axis.
+	// Segment
+	segment ulna_translation
+		parent ulna_parent_offset 
+		RTinMatrix	1
+		RT
+			1.0		0.0		0.0		0
+			0.0		1.0		0.0		0
+			0.0		0.0		1.0		0
+			0		0		0		1
+	endsegment
+
+	// Segment
+	segment ulna_rotation_0
+		parent ulna_translation 
+		RTinMatrix	1
+		RT
+			1.0		0.0		0.0		0
+			0.0		0.3919780619566715		-0.9199745642922371		0
+			0.0		0.9199745642922371		0.3919780619566715		0
+			0		0		0		1
+	endsegment
+
+	// Segment
+	segment ulna_rotation_1
+		parent ulna_rotation_0 
+		RTinMatrix	1
+		RT
+			0.6453279838685939		0.0		-0.7639056180157965		0
+			0.7027737380944746		0.3919780619566716		0.5936853307850977		0
+			0.2994342436676454		-0.9199745642922373		0.25295441244321765		0
+			0		0		0		1
+	endsegment
+
+	// Segment
+	segment ulna_elbow_flexion
+		parent ulna_rotation_1 
+		RTinMatrix	1
+		RT
+			0.08589634953351034		0.6013703041538472		0.794339709707834		0
+			-0.9949214186888451		0.09376465199613918		0.03660000915599257		0
+			-0.05247082780929644		-0.7934493980827966		0.6063702374878361		0
+			0		0		0		1
+		rotations z
+		// ranges
+				// 0 2.2689280275930002
+	endsegment
+
+
+    // Segment to cancel transformation bases effect.
+	// Segment
+	segment ulna_reset_axis
+		parent ulna_elbow_flexion 
+		RTinMatrix	1
+		RT
+			0.09551407821159333		-0.994921418688845		0.03175581045360772		0
+			0.9942015387447458		0.09376465199613916		-0.052644946515528354		0
+			0.04940001235798999		0.03660000915599253		0.9981082496947975		0
+			0		0		0		1
+	endsegment
+
+
+    //True segment where are applied inertial values.
+	// Segment
+	segment ulna
+		parent ulna_reset_axis 
+		RTinMatrix	0
+		RT	-0.0	 0.0	 -0.0	xyz	-0.0	 -0.0	 -0.0
+		mass	0.60750000000000004
+		inertia
+			0.0030912422797799129	0	0
+			0	0.00064496547228358751	0
+			0	0	0.0033531942758044772
+		com	0 -0.12312638689771148 0
+		meshfile	../biorbd/models/Geometry_cleaned/ulna.vtp
+		meshcolor	1 1 1
+		meshscale	1.021583795044277 1.021583795044277 1.021583795044277
+	endsegment
+
+	// Markers
+
+	marker	ULNA
+		parent	ulna
+		position	-0.0055679932448590985 -0.23120568806852537 0.056319343799689281
+	endmarker
+
+// Information about radius segment
+	// Segment
+	segment radius_parent_offset
+		parent ulna 
+		RTinMatrix	0
+		RT	0 0 0	xyz	0.0004086335180177108 -0.011751278394394318 0.020430654317090496
+	endsegment
+
+	// Segments to define transformation axis.
+	// Segment
+	segment radius_translation
+		parent radius_parent_offset 
+		RTinMatrix	1
+		RT
+			1.0		0.0		0.0		0
+			0.0		1.0		0.0		0
+			0.0		0.0		1.0		0
+			0		0		0		1
+	endsegment
+
+	// Segment
+	segment radius_rotation_0
+		parent radius_translation 
+		RTinMatrix	1
+		RT
+			1.0		0.0		0.0		0
+			0.0		0.9970952290299382		-0.07616498044203134		0
+			0.0		0.07616498044203134		0.9970952290299382		0
+			0		0		0		1
+	endsegment
+
+	// Segment
+	segment radius_pro_sup
+		parent radius_rotation_0 
+		RTinMatrix	1
+		RT
+			0.388425929945961		-0.01716099384199165		-0.9213201382993701		0
+			0.1861816424036899		0.9806676698277027		0.0602272146671952		0
+			0.9024753143313561		-0.19492670839333182		0.3841118136395457		0
+			0		0		0		1
+		rotations y
+		// ranges
+				// -1.570796326795 1.570796326795
+	endsegment
+
+	// Segment
+	segment radius_rotation_2
+		parent radius_pro_sup 
+		RTinMatrix	1
+		RT
+			0.37071584212969266		0.16465408854375393		0.9140343513894312		0
+			-0.14141162245791533		0.9826913722464635		-0.1196679570569417		0
+			-0.9179174894443903		-0.08489227313594375		0.3875832614212326		0
+			0		0		0		1
+		// ranges
+				// -1.570796326795 1.570796326795
+	endsegment
+
+
+    // Segment to cancel transformation bases effect.
+	// Segment
+	segment radius_reset_axis
+		parent radius_rotation_2 
+		RTinMatrix	1
+		RT
+			0.992118278029429		-0.12530491770046798		-4.8101740282870183e-17		0
+			0.12530491770046798		0.992118278029429		-1.4178179663497993e-18		0
+			4.3427629885068105e-17		-1.00339074274902e-18		1.0000000000000002		0
+			0		0		0		1
+	endsegment
+
+
+    //True segment where are applied inertial values.
+	// Segment
+	segment radius
+		parent radius_reset_axis 
+		RTinMatrix	0
+		RT	-0.0	 0.0	 -0.0	xyz	-0.0	 -0.0	 -0.0
+		mass	0.60750000000000004
+		inertia
+			0.0030912422797799129	0	0
+			0	0.00064496547228358751	0
+			0	0	0.0033531942758044772
+		com	0 -0.12312638689771148 0
+		meshfile	../biorbd/models/Geometry_cleaned/radius.vtp
+		meshcolor	1 1 1
+		meshscale	1.021583795044277 1.021583795044277 1.021583795044277
+	endsegment
+
+	// Markers
+
+	marker	RADIUS
+		parent	radius
+		position	0.062045310502069684 -0.21791924402960805 0.017585473680696517
+	endmarker
+
+// Information about hand_r segment
+	// Segment
+	segment hand_r_parent_offset
+		parent radius 
+		RTinMatrix	0
+		RT	0 0 0	xyz	0.017484304493803296 -0.23506643123968812 0.024283761916858992
+	endsegment
+
+
+    // Segment to cancel transformation bases effect.
+	// Segment
+	segment hand_r_reset_axis
+		parent hand_r_parent_offset 
+		RTinMatrix	1
+		RT
+			1.0		0.0		0.0		0
+			0.0		1.0		0.0		0
+			0.0		0.0		1.0		0
+			0		0		0		1
+	endsegment
+
+
+    //True segment where are applied inertial values.
+	// Segment
+	segment hand_r
+		parent hand_r_reset_axis 
+		RTinMatrix	0
+		RT	-0.0	 0.0	 -0.0	xyz	-0.0	 -0.0	 -0.0
+		mass	0.45750000000000002
+		inertia
+			0.0011035241554899452	0	0
+			0	0.00067671268279484301	0
+			0	0	0.001657760502641846
+		com	0 -0.075739724150060694 0
+		meshfile	../biorbd/models/Geometry_cleaned/lunate.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+	// Segment
+	segment hand_r_geom_1
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		-0.014891011482796278
+			0		1		0		-0.01099585744838094
+			0		0		1		-0.011782229208041601
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/pisiform.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_3
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		0.013730918490821635
+			0		1		0		-0.004965153515028576
+			0		0		1		-0.0013947810277432425
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/scaphoid.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_4
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		-0.01199467193236294
+			0		1		0		-0.00834087952715038
+			0		0		1		-0.0014337103227759487
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/triquetrum.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_5
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		-0.007760276898376876
+			0		1		0		-0.019519148529398855
+			0		0		1		0.001754042807616502
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/hamate.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_6
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		0.004440164164873225
+			0		1		0		-0.01674404592635309
+			0		0		1		0.0025882419868887762
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/capitate.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_7
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		0.014609608292988432
+			0		1		0		-0.021262068681291726
+			0		0		1		-0.00015238038341373544
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/trapezoid.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_8
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		0.02145004156302108
+			0		1		0		-0.021825987326479786
+			0		0		1		-0.008876991533029361
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/trapezium.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_9
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		0.029458353684034915
+			0		1		0		-0.02783222141724016
+			0		0		1		-0.011657655463936944
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/1mc.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_10
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		0.020773784095024353
+			0		1		0		-0.058587476758650364
+			0		0		1		0.008185162347019555
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/2mc.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_11
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		0.004970714842890391
+			0		1		0		-0.06038823472030612
+			0		0		1		0.010793425114210867
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/3mc.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_12
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		-0.008958186919811864
+			0		1		0		-0.06181193465293079
+			0		0		1		0.006495630942600109
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/4mc.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_13
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		-0.019914002807587733
+			0		1		0		-0.05532075277262014
+			0		0		1		-0.0021032941973384944
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/5mc.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_14
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		0.04781073562802495
+			0		1		0		-0.060310376130240706
+			0		0		1		-0.025783428232947454
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/thumbprox.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_15
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		0.0633824536411074
+			0		1		0		-0.08911805445444324
+			0		0		1		-0.03701731051381408
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/thumbdist.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_16
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		0.024667825863867333
+			0		1		0		-0.0900011933188995
+			0		0		1		0.012211563718973731
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/2proxph.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_17
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		0.033028726171320244
+			0		1		0		-0.13590773028703892
+			0		0		1		0.020360021302105305
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/2midph.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_18
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		0.03673590732400624
+			0		1		0		-0.16358979585201006
+			0		0		1		0.02171698530038821
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/2distph.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_19
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		0.005237658580257519
+			0		1		0		-0.08962969661773024
+			0		0		1		0.012771033301872337
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/3proxph.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_20
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		0.0070728967746565225
+			0		1		0		-0.13880406983747226
+			0		0		1		0.019700447817694026
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/3midph.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_21
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		0.008591139280932062
+			0		1		0		-0.17111204791790127
+			0		0		1		0.021873814746091395
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/3distph.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_22
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		-0.010993632917236212
+			0		1		0		-0.08816039379663868
+			0		0		1		0.006303208998581305
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/4proxph.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_23
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		-0.01491770585653299
+			0		1		0		-0.13293464441211253
+			0		0		1		0.007799206193409583
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/4midph.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_24
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		-0.017494825187698137
+			0		1		0		-0.16050659568541972
+			0		0		1		0.00842541171064997
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/4distph.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_25
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		-0.021690290926651496
+			0		1		0		-0.07915771625393228
+			0		0		1		-0.0037672434935935905
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/5proxph.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_26
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		-0.02756194088315594
+			0		1		0		-0.11871321680387882
+			0		0		1		-0.0069694560764267605
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/5midph.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+	// Segment
+	segment hand_r_geom_27
+		parent hand_r 
+		RTinMatrix	1
+		RT
+			1		0		0		-0.030755255341410208
+			0		1		0		-0.1417115320436292
+			0		0		1		-0.009464267755237041
+			0		0		0		1
+		meshfile	../biorbd/models/Geometry_cleaned/5distph.vtp
+		meshcolor	1 1 1
+		meshscale	1.1122655723630324 1.1122655723630324 1.1122655723630324
+	endsegment
+
+
+	// Markers
+
+	marker	SEML
+		parent	hand_r
+		position	-2.870979499874915e-05 -0.028397092471877383 0.025584440352950488
+	endmarker
+
+	marker	MET2
+		parent	hand_r
+		position	0.025627702742705871 -0.065897210048525667 0.037768660499899687
+	endmarker
+
+	marker	MET5
+		parent	hand_r
+		position	-0.027079917714738277 -0.060199721937794437 0.019621605095738293
+	endmarker
+
+// MUSCLE DEFINIION
+
+// thorax > scapula
+musclegroup thorax_to_scapula
+	OriginParent	thorax
+	InsertionParent	scapula
+endmusclegroup
+
+	muscle	LVS
+		type	hill
+		statetype	degroote
+		musclegroup	thorax_to_scapula
+		OriginPosition	-0.038354129111817986 0.092439280084944189 0.022543799999999999
+		InsertionPosition	-0.067647100000000002 0.00067274132337001406 -0.095175441459486559
+		optimalLength	0.14897371558402536
+		maximalForce	169.95639725599801
+		tendonSlackLength	0.0052673495500779556
+		pennationAngle	0
+	endmuscle
+
+	muscle	TRP2
+		type	hill
+		statetype	degroote
+		musclegroup	thorax_to_scapula
+		OriginPosition	-0.079740625445178182 0.030792080978762286 0.0035691299999999998
+		InsertionPosition	-0.039 -0.0025832563993960834 -0.0099500218454616467
+		optimalLength	0.08777311531414006
+		maximalForce	162.449964047061
+		tendonSlackLength	0.044046536998511979
+		pennationAngle	0
+	endmuscle
+
+	muscle	TRP3
+		type	hill
+		statetype	degroote
+		musclegroup	thorax_to_scapula
+		OriginPosition	-0.094864378124900631 -0.015078897070670394 0.0025060199999999999
+		InsertionPosition	-0.058344 -0.0065134643305282498 -0.044193718528147088
+		optimalLength	0.080837409544661148
+		maximalForce	155.28316683500699
+		tendonSlackLength	0.019665364181553253
+		pennationAngle	0
+	endmuscle
+
+	muscle	TRP4
+		type	hill
+		statetype	degroote
+		musclegroup	thorax_to_scapula
+		OriginPosition	-0.11937713679837272 -0.10333002423697976 0.00068362499999999999
+		InsertionPosition	-0.079191899999999996 -0.012951703338165923 -0.078505771860910845
+		optimalLength	0.12638689206631343
+		maximalForce	557.24345537557701
+		tendonSlackLength	0.0049287977581734073
+		pennationAngle	0
+	endmuscle
+
+	muscle	RMN
+		type	hill
+		statetype	degroote
+		musclegroup	thorax_to_scapula
+		OriginPosition	-0.064844755764284501 0.054777422391559534 0.0030000000000000001
+		InsertionPosition	-0.079057000000000002 -0.013161129516418082 -0.099757924020413918
+		optimalLength	0.10877204719637304
+		maximalForce	301.61706145578802
+		tendonSlackLength	0.023291895380088152
+		pennationAngle	0
+	endmuscle
+
+	muscle	RMJ1
+		type	hill
+		statetype	degroote
+		musclegroup	thorax_to_scapula
+		OriginPosition	-0.08137388986496813 0.009240267155451275 0.00143378
+		InsertionPosition	-0.0903423 -0.04228987944634769 -0.10365733758165034
+		optimalLength	0.090525405882897023
+		maximalForce	185.935898822876
+		tendonSlackLength	0.024926628416222528
+		pennationAngle	0
+	endmuscle
+
+	muscle	RMJ2
+		type	hill
+		statetype	degroote
+		musclegroup	thorax_to_scapula
+		OriginPosition	-0.089547519864964314 -0.024470942801755279 0.00143378
+		InsertionPosition	-0.10000000000000001 -0.099059682976415653 -0.096515211900977976
+		optimalLength	0.089786662609986689
+		maximalForce	111.570078855478
+		tendonSlackLength	0.046838954864813001
+		pennationAngle	0
+	endmuscle
+
+	muscle	SRA1
+		type	hill
+		statetype	degroote
+		musclegroup	thorax_to_scapula
+		OriginPosition	-0.00097167396236370266 -0.054977692587449098 0.11981899999999999
+		InsertionPosition	-0.087849800000000006 -0.04727498294692143 -0.0980829373429489
+		optimalLength	0.087212665706146372
+		maximalForce	365.11775335508798
+		tendonSlackLength	0.071441985287189591
+		pennationAngle	0
+	endmuscle
+
+	muscle	SRA2
+		type	hill
+		statetype	degroote
+		musclegroup	thorax_to_scapula
+		OriginPosition	-0.00064425117559124205 -0.099852213845994311 0.137825
+		InsertionPosition	-0.093100100000000005 -0.062327652106759876 -0.09802592371777441
+		optimalLength	0.12940786597423884
+		maximalForce	179.96260532400399
+		tendonSlackLength	0.042542991696600856
+		pennationAngle	0
+	endmuscle
+
+	muscle	SRA3
+		type	hill
+		statetype	degroote
+		musclegroup	thorax_to_scapula
+		OriginPosition	-0.011706434050944658 -0.15839258205406534 0.148868
+		InsertionPosition	-0.096883499999999997 -0.077465472569843707 -0.097751402615058117
+		optimalLength	0.13280547898553621
+		maximalForce	377.92166433725902
+		tendonSlackLength	0.0087364343732339103
+		pennationAngle	0
+	endmuscle
+
+// thorax > clavicle
+musclegroup thorax_to_clavicle
+	OriginParent	thorax
+	InsertionParent	clavicle
+endmusclegroup
+
+	muscle	TRP1
+		type	hill
+		statetype	degroote
+		musclegroup	thorax_to_clavicle
+		OriginPosition	-0.060686560068853826 0.094800236646457522 0.0019247699999999999
+		InsertionPosition	-0.042636058224653307 0.024845900000000001 0.098256899999999994
+		optimalLength	0.10058518056114195
+		maximalForce	280.56713981164
+		tendonSlackLength	0.015066196509909813
+		pennationAngle	0
+	endmuscle
+
+	muscle	SBCL
+		type	hill
+		statetype	degroote
+		musclegroup	thorax_to_clavicle
+		OriginPosition	-0.00095503150433270717 -0.012919678961614717 0.0391262
+		InsertionPosition	-0.021943402927804383 0.0090854600000000001 0.075709299999999993
+		optimalLength	0.0244214227345541
+		maximalForce	195.80764894274199
+		tendonSlackLength	0.044527421986811443
+		pennationAngle	0
+	endmuscle
+
+// scapula > thorax
+musclegroup scapula_to_thorax
+	OriginParent	scapula
+	InsertionParent	thorax
+endmusclegroup
+
+	muscle	PMN
+		type	hill
+		statetype	degroote
+		musclegroup	scapula_to_thorax
+		OriginPosition	0.012 -0.041294879964006805 -0.026387457934164284
+		InsertionPosition	0.033395049218606525 -0.073489373514349726 0.0894181
+		optimalLength	0.11687099550957379
+		maximalForce	218.72293530659101
+		tendonSlackLength	0.0050782716361936243
+		pennationAngle	0
+	endmuscle
+
+// humerus > clavicle
+musclegroup humerus_to_clavicle
+	OriginParent	humerus
+	InsertionParent	clavicle
+endmusclegroup
+
+	muscle	DELT1
+		type	hill
+		statetype	degroote
+		musclegroup	humerus_to_clavicle
+		OriginPosition	0.0038752434999999997 -0.10187001999999999 0.0065918859999999999
+		InsertionPosition	-0.033677243893434607 0.019284200000000001 0.099015000000000006
+		optimalLength	0.17862531668340353
+		maximalForce	556.79999999999995
+		tendonSlackLength	0.031911942991955086
+		pennationAngle	0.383972435439
+	endmuscle
+
+		viapoint	DELT1-P3
+			parent	clavicle
+			muscle	DELT1
+			musclegroup	humerus_to_clavicle
+			position	-0.0032142932154970868 0.031505100000000001 0.13061800000000001
+		endviapoint
+
+	muscle	PECM1
+		type	hill
+		statetype	degroote
+		musclegroup	humerus_to_clavicle
+		OriginPosition	0.013599999999999999 -0.039685786000000001 0.0042500000000000003
+		InsertionPosition	0.0015403313794683361 0.0060833399999999996 0.0513213
+		optimalLength	0.10238891827956645
+		maximalForce	983.39999999999998
+		tendonSlackLength	0.04794798124311405
+		pennationAngle	0.29670597283900002
+	endmuscle
+
+		viapoint	PECM1-P2
+			parent	clavicle
+			muscle	PECM1
+			musclegroup	humerus_to_clavicle
+			position	-0.00067696994212547532 0.0055703899999999997 0.059160499999999998
+		endviapoint
+
+// humerus > scapula
+musclegroup humerus_to_scapula
+	OriginParent	humerus
+	InsertionParent	scapula
+endmusclegroup
+
+	muscle	DELT2
+		type	hill
+		statetype	degroote
+		musclegroup	humerus_to_scapula
+		OriginPosition	0.0038752434999999997 -0.10187001999999999 0.0065918859999999999
+		InsertionPosition	-0.027529399999999999 -0.0032041304730007895 0.0014192114159055763
+		optimalLength	0.12839265558104354
+		maximalForce	1098.4000000000001
+		tendonSlackLength	0.045492693593586743
+		pennationAngle	0.26179938779900003
+	endmuscle
+
+		viapoint	default
+			parent	humerus
+			muscle	DELT2
+			musclegroup	humerus_to_scapula
+			position	-0.0029752124999999998 -0.056788941999999995 0.024106934999999999
+		endviapoint
+
+		viapoint	DELT2-P3
+			parent	scapula
+			muscle	DELT2
+			musclegroup	humerus_to_scapula
+			position	-0.027642099999999999 -0.0048423975209162017 0.018269334610670585
+		endviapoint
+
+	muscle	SUPSP
+		type	hill
+		statetype	degroote
+		musclegroup	humerus_to_scapula
+		OriginPosition	0.012116664999999999 0.016507413999999998 0.017802229999999999
+		InsertionPosition	-0.067039799999999997 -0.01159648682681989 -0.064175053897547796
+		optimalLength	0.11318558801894239
+		maximalForce	410.69999999999999
+		tendonSlackLength	0.024094442771414346
+		pennationAngle	0.12217304764
+	endmuscle
+
+		viapoint	SUPSP-P2
+			parent	humerus
+			muscle	SUPSP
+			musclegroup	humerus_to_scapula
+			position	0.0030309299999999998 0.030606674 0.0046898749999999996
+		endviapoint
+
+		viapoint	SUPSP-P2_0
+			parent	scapula
+			muscle	SUPSP
+			musclegroup	humerus_to_scapula
+			position	-0.056179699999999999 -0.0013378960758680363 -0.040500369919330176
+		endviapoint
+
+	muscle	INFSP
+		type	hill
+		statetype	degroote
+		musclegroup	humerus_to_scapula
+		OriginPosition	-0.0043329344999999998 0.0078800525999999996 0.022437194999999997
+		InsertionPosition	-0.087984999999999994 -0.05458568761086674 -0.069006585505267073
+		optimalLength	0.12856503035137123
+		maximalForce	864.60000000000002
+		tendonSlackLength	0.032748613173402955
+		pennationAngle	0.32288591161899999
+	endmuscle
+
+		viapoint	INFSP-P2
+			parent	scapula
+			muscle	INFSP
+			musclegroup	humerus_to_scapula
+			position	-0.042663899999999998 -0.048514729888414147 -0.021795423352265284
+		endviapoint
+
+	muscle	SUBSC
+		type	hill
+		statetype	degroote
+		musclegroup	humerus_to_scapula
+		OriginPosition	0.016999574999999999 -0.0081454953999999993 -0.0014864205
+		InsertionPosition	-0.071999999999999995 -0.039023511475557673 -0.064675141995500701
+		optimalLength	0.15967541111623323
+		maximalForce	944.29999999999995
+		tendonSlackLength	0.007338024407915129
+		pennationAngle	0.34906585039900001
+	endmuscle
+
+		viapoint	SUBSC-P2
+			parent	humerus
+			muscle	SUBSC
+			musclegroup	humerus_to_scapula
+			position	0.0063167155000000003 0.010167107999999999 -0.019282674999999999
+		endviapoint
+
+		viapoint	default
+			parent	scapula
+			muscle	SUBSC
+			musclegroup	humerus_to_scapula
+			position	-0.039108799999999999 -0.032307465090328363 -0.033204615901363879
+		endviapoint
+
+	muscle	TMIN
+		type	hill
+		statetype	degroote
+		musclegroup	humerus_to_scapula
+		OriginPosition	0.0055728804999999994 -0.0035810866 0.018426385
+		InsertionPosition	-0.082000400000000001 -0.067521781544442439 -0.040726036414785241
+		optimalLength	0.043991956829814986
+		maximalForce	605.39999999999998
+		tendonSlackLength	0.10080276200739063
+		pennationAngle	0.418879020479
+	endmuscle
+
+		viapoint	TMIN-P1_0
+			parent	humerus
+			muscle	TMIN
+			musclegroup	humerus_to_scapula
+			position	-0.0072057134999999996 -0.013893263999999999 0.022852165000000001
+		endviapoint
+
+		viapoint	TMIN-P2
+			parent	scapula
+			muscle	TMIN
+			musclegroup	humerus_to_scapula
+			position	-0.075018899999999999 -0.052682540974289538 -0.010216483430483109
+		endviapoint
+
+	muscle	TMAJ
+		type	hill
+		statetype	degroote
+		musclegroup	humerus_to_scapula
+		OriginPosition	0.0031441500000000001 -0.0441 -0.0057485839999999993
+		InsertionPosition	-0.104709 -0.10782196220696587 -0.070799877942474609
+		optimalLength	0.13873412511849612
+		maximalForce	234.90000000000001
+		tendonSlackLength	0.053674513824663116
+		pennationAngle	0.27925268031900002
+	endmuscle
+
+		viapoint	default
+			parent	scapula
+			muscle	TMAJ
+			musclegroup	humerus_to_scapula
+			position	-0.045351900000000001 -0.10628003320225217 -0.0024591777491713824
+		endviapoint
+
+// scapula > humerus
+musclegroup scapula_to_humerus
+	OriginParent	scapula
+	InsertionParent	humerus
+endmusclegroup
+
+	muscle	DELT3
+		type	hill
+		statetype	degroote
+		musclegroup	scapula_to_humerus
+		OriginPosition	-0.059062499999999997 -0.0015696557099185151 -0.038268381018956216
+		InsertionPosition	0.0038752434999999997 -0.10187001999999999 0.0065918859999999999
+		optimalLength	0.12168303750339739
+		maximalForce	944.70000000000005
+		tendonSlackLength	0.096613160884212096
+		pennationAngle	0.31415926535900002
+	endmuscle
+
+		viapoint	DELT3-P2
+			parent	scapula
+			muscle	DELT3
+			musclegroup	scapula_to_humerus
+			position	-0.072188100000000005 -0.023734399860291685 0.0059474066576440986
+		endviapoint
+
+		viapoint	DELT3-P2_0
+			parent	humerus
+			muscle	DELT3
+			musclegroup	scapula_to_humerus
+			position	-0.015796825 -0.048707960000000002 0.0050155440000000003
+		endviapoint
+
+	muscle	CORB
+		type	hill
+		statetype	degroote
+		musclegroup	scapula_to_humerus
+		OriginPosition	0.012500000000000001 -0.041294879964006805 -0.026387457934164284
+		InsertionPosition	0 -0.12544 -0.0099104899999999992
+		optimalLength	0.081763395438906539
+		maximalForce	306.89999999999998
+		tendonSlackLength	0.060438086772749429
+		pennationAngle	0
+	endmuscle
+
+// humerus > thorax
+musclegroup humerus_to_thorax
+	OriginParent	humerus
+	InsertionParent	thorax
+endmusclegroup
+
+	muscle	PECM2
+		type	hill
+		statetype	degroote
+		musclegroup	humerus_to_thorax
+		OriginPosition	0.013599999999999999 -0.034785785999999999 0.0042500000000000003
+		InsertionPosition	0.025593916315611837 -0.046576230620979264 0.0174664
+		optimalLength	0.14296164500908479
+		maximalForce	699.70000000000005
+		tendonSlackLength	0.097520264988339975
+		pennationAngle	0.43633231299899999
+	endmuscle
+
+		viapoint	PECM2-P2
+			parent	thorax
+			muscle	PECM2
+			musclegroup	humerus_to_thorax
+			position	0.043556325375053655 -0.04255124994894656 0.080812499999999995
+		endviapoint
+
+	muscle	PECM3
+		type	hill
+		statetype	degroote
+		musclegroup	humerus_to_thorax
+		OriginPosition	0.013599999999999999 -0.029399999999999999 0.0042500000000000003
+		InsertionPosition	0.064488933033050963 -0.14463208149778231 0.022060199999999999
+		optimalLength	0.18298157388425934
+		maximalForce	446.69999999999999
+		tendonSlackLength	0.09971637892865319
+		pennationAngle	0.43633231299899999
+	endmuscle
+
+		viapoint	PECM3-P2
+			parent	thorax
+			muscle	PECM3
+			musclegroup	humerus_to_thorax
+			position	0.044535172402543094 -0.091091616322965918 0.082833000000000004
+		endviapoint
+
+	muscle	LAT
+		type	hill
+		statetype	degroote
+		musclegroup	humerus_to_thorax
+		OriginPosition	0.0084298920000000013 -0.021887026 -0.0074986999999999996
+		InsertionPosition	-0.09747504857760747 -0.15759091396787986 0.00051214399999999997
+		optimalLength	0.22717282303674899
+		maximalForce	1129.7
+		tendonSlackLength	0.075495500102847099
+		pennationAngle	0.33161255787900001
+	endmuscle
+
+		viapoint	LAT-P2
+			parent	humerus
+			muscle	LAT
+			musclegroup	humerus_to_thorax
+			position	0.0017181305 -0.018512984 -0.018245335000000001
+		endviapoint
+
+/*-------------- WARNINGS---------------
+
+Some wrapping objects were present on the muscles :['TRP1', 'TRP2', 'TRP4', 'RMN', 'RMJ1', 'RMJ2', 'SRA1', 'SRA2', 'SRA3', 'SUPSP', 'INFSP', 'LAT', 'CORB'] in the original file force set.
+Only via point are supported in biomod so they will be ignored.*/

--- a/pyorerun/__init__.py
+++ b/pyorerun/__init__.py
@@ -3,13 +3,24 @@ from .live_integration import LiveModelIntegration
 from .model_components.model_display_options import DisplayModelOptions
 from .model_components.model_updapter import ModelUpdater
 
+# Opensim
 try:
     from .model_interfaces import (
         OsimModel,
         OsimModelNoMesh,
     )
 except ImportError:
-    # OpenSim n'est pas installé, ces classes ne seront pas disponibles
+    # OpenSim is not installed, these classes will not be available
+    pass
+
+# biobuddy
+try:
+    from .model_interfaces import (
+        BiobuddyModel,
+        BiobuddyModelNoMesh,
+    )
+except ImportError:
+    # BioBuddy is not installed, these classes will not be available
     pass
 
 from .model_interfaces import (

--- a/pyorerun/model_interfaces/__init__.py
+++ b/pyorerun/model_interfaces/__init__.py
@@ -1,10 +1,18 @@
 from .abstract_model_interface import AbstractSegment, AbstractModel, AbstractModelNoMesh
 from .biorbd_model_interface import BiorbdModelNoMesh, BiorbdModel
 
+# Opensim
 try:
     from .osim_model_interface import OsimModelNoMesh, OsimModel
 except ImportError:
-    # OpenSim n'est pas installé, ces classes ne seront pas disponibles
+    # OpenSim is not installed, these classes will not be available
+    pass
+
+# Biobuddy
+try:
+    from .biobuddy_model_interface import BiobuddyModelNoMesh, BiobuddyModel
+except ImportError:
+    # BioBuddy is not installed, these classes will not be available
     pass
 
 from .available_interfaces import model_from_file

--- a/pyorerun/model_interfaces/biobuddy_model_interface.py
+++ b/pyorerun/model_interfaces/biobuddy_model_interface.py
@@ -58,7 +58,7 @@ class BiobuddyModelNoMesh(AbstractModelNoMesh):  # Inherits from AbstractModelNo
     A class to handle a biorbd model and its transformations
     """
 
-    def __init__(self, path: str=None, options=None):
+    def __init__(self, path: str = None, options=None):
         """
         A biobuddy.BioemchanicalModelReal cannot be created from a path directly, so we need to use the
         BiobuddyModelNoMesh.from_biobuddy_object() to set it.
@@ -102,12 +102,12 @@ class BiobuddyModelNoMesh(AbstractModelNoMesh):  # Inherits from AbstractModelNo
 
     @cached_property
     def segments(self):
-        """ Returns a NamedList[SegmentReal] """
+        """Returns a NamedList[SegmentReal]"""
         return self.model.segments
 
     @cached_property
     def segments_with_mass(self) -> tuple:
-        """ Returns a tuple[SegmentReal] """
+        """Returns a tuple[SegmentReal]"""
         segments_with_mass_list = []
         for s in self.segments:
             inertia_parameters = s.segment.inertia_parameters
@@ -312,11 +312,7 @@ class BiobuddyModel(BiobuddyModelNoMesh, AbstractModel):  # Inherits from Biobud
             # If q contains NaN, return an identity matrix as biorbd will throw an error otherwise
             return np.identity(4)
         else:
-            mesh_rt = (
-                super(BiobuddyModel, self)
-                .segments[segment_index]
-                .mesh_file.mesh_rt.rt_matrix
-            )
+            mesh_rt = super(BiobuddyModel, self).segments[segment_index].mesh_file.mesh_rt.rt_matrix
 
             # mesh_rt = self.segments[segment_index].segment.characteristics().mesh().getRotation().to_array()
             segment_rt = self.segment_homogeneous_matrices_in_global(q, segment_index=segment_index)

--- a/pyorerun/model_interfaces/biobuddy_model_interface.py
+++ b/pyorerun/model_interfaces/biobuddy_model_interface.py
@@ -1,0 +1,323 @@
+from functools import cached_property
+
+import numpy as np
+
+# Import the abstract classes
+from .abstract_model_interface import AbstractModel, AbstractModelNoMesh, AbstractSegment
+
+MINIMAL_SEGMENT_MASS = 1e-08
+
+
+class BiobuddySegment(AbstractSegment):  # Inherits from AbstractSegment
+    """
+    An interface to simplify the access to a segment of a biobuddy model
+    """
+
+    def __init__(self, segment, index):
+        self.segment = segment
+        self._index: int = index
+
+    @cached_property
+    def name(self) -> str:
+        return self.segment.name
+
+    @cached_property
+    def id(self) -> int:
+        return self._index
+
+    @cached_property
+    def has_mesh(self) -> bool:
+        has_mesh = self.segment.mesh_file is not None
+        if has_mesh:
+            return not self.segment.mesh_file.mesh_file_name.endswith("/")  # Avoid empty mesh path
+        return has_mesh
+
+    @cached_property
+    def has_meshlines(self) -> bool:
+        has_mesh = self.segment.mesh is not None
+        return has_mesh
+
+    @cached_property
+    def mesh_path(self) -> list[str]:
+        return [self.segment.mesh_file.mesh_file_name]
+
+    @cached_property
+    def mesh_scale_factor(self) -> list[np.ndarray]:
+        """
+        return: numpy array (3,) of the scale factor of the mesh
+        """
+        return [self.segment.mesh_file.mesh_scale.reshape(-1)[:3]]
+
+    @cached_property
+    def mass(self) -> float:
+        return self.segment.mass
+
+
+class BiobuddyModelNoMesh(AbstractModelNoMesh):  # Inherits from AbstractModelNoMesh
+    """
+    A class to handle a biorbd model and its transformations
+    """
+
+    def __init__(self, path: str=None, options=None):
+        """
+        A biobuddy.BioemchanicalModelReal cannot be created from a path directly, so we need to use the
+        BiobuddyModelNoMesh.from_biobuddy_object() to set it.
+        """
+        if path is not None:
+            raise NotImplementedError("Loading a model from a path is not implemented yet for BioBuddy.")
+        super().__init__(path, options)
+        self.model = None
+
+    @classmethod
+    def from_biobuddy_object(cls, model: "biobuddy.BioemchanicalModelReal", options=None):
+        """
+        model is a biobuddy.BioemchanicalModelReal object, but we cannot enforce it here due to circular import between
+        biobuddy and pyorerun libraries.
+        """
+        new_object = cls(None, None)
+        new_object.model = model
+        if options is not None:
+            new_object.options = options
+        return new_object
+
+    @cached_property
+    def name(self):
+        return "BioBuddy model"
+
+    @cached_property
+    def marker_names(self) -> tuple[str, ...]:
+        return self.model.marker_names
+
+    @cached_property
+    def nb_markers(self) -> int:
+        return self.model.nb_markers
+
+    @cached_property
+    def segment_names(self) -> tuple[str, ...]:
+        return self.model.segment_names
+
+    @cached_property
+    def nb_segments(self) -> int:
+        return self.model.nb_segments
+
+    @cached_property
+    def segments(self):
+        """ Returns a NamedList[SegmentReal] """
+        return self.model.segments
+
+    @cached_property
+    def segments_with_mass(self) -> tuple:
+        """ Returns a tuple[SegmentReal] """
+        segments_with_mass_list = []
+        for s in self.segments:
+            inertia_parameters = s.segment.inertia_parameters
+            if inertia_parameters is not None:
+                mass = inertia_parameters.mass
+                if mass > MINIMAL_SEGMENT_MASS:
+                    segments_with_mass_list.append(s)
+        return tuple(segments_with_mass_list)
+
+    @cached_property
+    def segment_names_with_mass(self) -> tuple[str, ...]:
+        return tuple([s.name for s in self.segments_with_mass])
+
+    def segment_homogeneous_matrices_in_global(self, q: np.ndarray, segment_index: int) -> np.ndarray:
+        """
+        Returns a biorbd object containing the roto-translation matrix of the segment in the global reference frame.
+        This is useful if you want to interact with biorbd directly later on.
+        """
+        if np.sum(np.isnan(q)) != 0:
+            # If q contains NaN, return an identity matrix as biorbd will throw an error otherwise
+            rt_matrix = np.identity(4)
+        else:
+            segment_name = self.model.segment_names[segment_index]
+            rt_matrix = self.model.forward_kinematics(q)[segment_name][0].rt_matrix
+        return rt_matrix
+
+    def markers(self, q: np.ndarray) -> np.ndarray:
+        """
+        Returns a [N_markers x 3] array containing the position of each marker in the global reference frame
+        """
+        return self.model.markers_in_global(q)[:3, :, 0].T
+
+    def centers_of_mass(self, q: np.ndarray) -> np.ndarray:
+        """
+        Returns a [N_segment_with_mass x 3] array containing the position of the centers of mass in the global reference frame
+        """
+        segments_com = np.empty((0, 3))
+        for s in self.segments_with_mass:
+            com = self.model.segment_com_in_global(s.segment.name, q)[:3, 0]
+            segments_com = np.vstack((segments_com, com))
+        return segments_com
+
+    @cached_property
+    def nb_ligaments(self) -> int:
+        """
+        Returns the number of ligaments
+        * Not implemented in biobuddy yet, so returns 0 for now *
+        """
+        return 0
+
+    @cached_property
+    def ligament_names(self) -> tuple[str, ...]:
+        """
+        Returns the names of the ligaments
+        * Not implemented in biobuddy yet, so returns 0 for now *
+        """
+        return ()
+
+    def ligament_strips(self, q: np.ndarray) -> list[list[np.ndarray]]:
+        """
+        Returns the position of the ligaments in the global reference frame
+        * Not implemented in biobuddy yet, so returns 0 for now *
+        """
+        return []
+
+    @cached_property
+    def nb_muscles(self) -> int:
+        """
+        Returns the number of muscles
+        """
+        return self.model.nb_muscles
+
+    @cached_property
+    def muscle_names(self) -> tuple[str, ...]:
+        """
+        Returns the names of the muscles
+        """
+        return self.model.muscle_names
+
+    def muscle_strips(self, q: np.ndarray) -> list[list[np.ndarray]]:
+        """
+        Returns the position of the muscles in the global reference frame
+        """
+        muscles = []
+        for muscle_group in self.model.muscle_groups:
+            for muscle in muscle_group.muscles:
+                muscle_strip = []
+                muscle_strip += [self.model.muscle_origin_in_global(muscle.name, q)[:3, 0].tolist()]
+                if muscle.nb_via_points > 0:
+                    muscle_strip += self.model.via_points_in_global(muscle.name, q)[:3, 0].T.tolist()
+                muscle_strip += [self.model.muscle_insertion_in_global(muscle.name, q)[:3, 0].tolist()]
+                muscles += [muscle_strip]
+        return muscles
+
+    @cached_property
+    def nb_q(self) -> int:
+        return self.model.nb_q
+
+    @cached_property
+    def dof_names(self) -> tuple[str, ...]:
+        return self.model.dof_names
+
+    @cached_property
+    def q_ranges(self) -> tuple[tuple[float, float], ...]:
+        q_ranges = [q_range for segment in self.model.segments for q_range in segment.ranges_q]
+        return tuple((q_range.min(), q_range.max()) for q_range in q_ranges)
+
+    @cached_property
+    def gravity(self) -> np.ndarray:
+        return self.model.gravity
+
+    @cached_property
+    def has_mesh(self) -> bool:
+        return any([s.has_mesh for s in self.segments])
+
+    @cached_property
+    def has_meshlines(self) -> bool:
+        return any([s.has_meshlines for s in self.segments])
+
+    @cached_property
+    def has_soft_contacts(self) -> bool:
+        """
+        * Not implemented in biobuddy yet, so returns False for now *
+        """
+        return False
+
+    @property
+    def has_rigid_contacts(self) -> bool:
+        return self.model.nb_contacts > 0
+
+    def soft_contacts(self, q: np.ndarray) -> np.ndarray:
+        """
+        Returns the position of the soft contacts spheres in the global reference frame
+        * Not implemented in biobuddy yet, so returns an empty array for now *
+        """
+        return np.array([])
+
+    def rigid_contacts(self, q: np.ndarray) -> np.ndarray:
+        """
+        Returns the position of the rigid contacts in the global reference frame
+        """
+        return self.model.contacts_in_global(q)[:3, :, 0].T
+
+    @cached_property
+    def soft_contacts_names(self) -> tuple[str, ...]:
+        """
+        Returns the names of the soft contacts
+        * Not implemented in biobuddy yet, so returns an empty tuple for now *
+        """
+        return ()
+
+    @cached_property
+    def rigid_contacts_names(self) -> tuple[str, ...]:
+        """
+        Returns the names of the soft contacts
+        """
+        return self.model.contact_names
+
+    @cached_property
+    def soft_contact_radii(self) -> tuple[float, ...]:
+        """
+        Returns the radii of the soft contacts
+        * Not implemented in biobuddy yet, so returns an empty tuple for now *
+        """
+        return ()
+
+
+class BiobuddyModel(BiobuddyModelNoMesh, AbstractModel):  # Inherits from BiobuddyModelNoMesh and AbstractModel
+    """
+    This class extends the BiobuddyModelNoMesh class and overrides the segments property.
+    It filters the segments to only include those that have a mesh.
+    """
+
+    def __init__(self, path, options=None):
+        super().__init__(path, options)
+
+    @property
+    def segments(self) -> tuple[BiobuddySegment, ...]:
+        segments_with_mesh = []
+        for i, s in enumerate(self.model.segments):
+            segment = BiobuddySegment(s, i)
+            if segment.has_mesh or segment.has_meshlines:
+                segments_with_mesh.append(segment)
+        return tuple(segments_with_mesh)
+
+    @cached_property
+    def meshlines(self) -> list[np.ndarray]:
+
+        # TODO
+        meshes = []
+        for segment in self.segments:
+            segment_mesh = segment.segment.mesh
+            meshes += [np.array([segment_mesh.point(i).to_array() for i in range(segment_mesh.nbVertex())])]
+
+        return meshes
+
+    def mesh_homogenous_matrices_in_global(self, q: np.ndarray, segment_index: int, **kwargs) -> np.ndarray:
+        """
+        Returns a list of homogeneous matrices of the mesh in the global reference frame
+        """
+        if np.sum(np.isnan(q)) != 0:
+            # If q contains NaN, return an identity matrix as biorbd will throw an error otherwise
+            return np.identity(4)
+        else:
+            mesh_rt = (
+                super(BiobuddyModel, self)
+                .segments[segment_index]
+                .mesh_file.mesh_rt.rt_matrix
+            )
+
+            # mesh_rt = self.segments[segment_index].segment.characteristics().mesh().getRotation().to_array()
+            segment_rt = self.segment_homogeneous_matrices_in_global(q, segment_index=segment_index)
+            return segment_rt @ mesh_rt


### PR DESCRIPTION
Answering to Issue #62

I have some questions:
1. Why is GlobalJCS(q) called for reach segments independently instead of for all segments at the same time and then using each segment in the matrix (ex: all_gcj[segment_idx, :] ?
2. Where are the tests for the model interfaces (so that I can test that I implemented everything correctly) ?
3. @pariterre is the key word `ranges` or `rangesq` or both recognized by biorbd ?